### PR TITLE
Check whether Hammer of Wrath talent is selected before suggesting it

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -104,7 +104,7 @@ function Paladin:Retribution(timeShift, currentSpell, gcd, talents)
 		return _Judgment;
 	end
 
-	if MaxDps:SpellAvailable(_HammerofWrath, timeShift) and holyPower <=4 and tgtPctHp < execPct then
+	if talents[_HammerofWrath] and MaxDps:SpellAvailable(_HammerofWrath, timeShift) and holyPower <=4 and tgtPctHp < execPct then
 		return _HammerofWrath;
 	end
 


### PR DESCRIPTION
Before this change, if the Hammer of Wrath talent wasn't selected, MaxDps would issue the error `Spell not found on action bars: Hammer of Wrath(24275)`.

Thanks for your work on this add-on!