### PR TITLE
removed arcane torrent

### DIFF
--- a/Specialization/Protection.lua
+++ b/Specialization/Protection.lua
@@ -10,7 +10,6 @@ local MaxDps = MaxDps;
 
 local HolyPower = Enum.PowerType.HolyPower;
 local PR = {
-	ArcaneTorrent = 28730,
 	AshenHallow = 316958,
 	AvengersShield = 31935,
 	AvengingWrath = 31884,
@@ -147,10 +146,6 @@ function Paladin:ProtectionMultiTarget()
 
 	if talents[PR.HammerOfTheRighteous] and cooldown[PR.HammerOfTheRighteous].ready then
 		return PR.HammerOfTheRighteous;
-	end
-
-	if cooldown[PR.ArcaneTorrent].ready then
-		return PR.ArcaneTorrent;
 	end
 
 	if cooldown[PR.Consecration].ready then

--- a/Specialization/Retribution.lua
+++ b/Specialization/Retribution.lua
@@ -8,7 +8,6 @@ local MaxDps = MaxDps;
 local UnitPower = UnitPower;
 local HolyPower = Enum.PowerType.HolyPower;
 local RT = {
-	ArcaneTorrent = 28730,
 	AvengingWrath = 31884,
 	AvengingWrathTalent = 384376,
 	AvengingWrathMightTalent = 384442,
@@ -132,10 +131,6 @@ function Paladin:RetributionSingleTarget()
 	if cooldown[RT.CrusaderStrike].ready then
 		return RT.CrusaderStrike;
 	end
-
-	if cooldown[RT.ArcaneTorrent].ready then
-		return RT.ArcaneTorrent;
-	end
 end
 
 
@@ -207,10 +202,6 @@ function Paladin:RetributionMultiTarget()
 
 	if cooldown[RT.CrusaderStrike].ready then
 		return RT.CrusaderStrike;
-	end
-
-	if cooldown[RT.ArcaneTorrent].ready then
-		return RT.ArcaneTorrent;
 	end
 end
 


### PR DESCRIPTION
removed the arcane torrent code as it is a racial and no code checking for race was added. 

Note: It is my opinion that racial cooldowns should be managed by the user and not part of the standard rotation. 